### PR TITLE
Added Tooltips to Bar Charts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import skinny_fruit from "./data/skinny_fruit.json"
 function App() {
   return (
     <div className="app">
-      <PieChart
+      {/* <PieChart
         data={fruit}
         label="label"
         value="value"
@@ -28,7 +28,7 @@ function App() {
         value="value"
         innerRadius="70%"
         outerRadius="80%"
-      /> 
+      />
       <AreaChart
         data={penguins}
         height="700"
@@ -67,7 +67,7 @@ function App() {
         // yGrid={true}
         xAxisLabel="Date"
         yAxisLabel="Value"
-      />
+      /> */}
       <BarChart
         height="300"
         data={skinny_fruit}
@@ -92,7 +92,7 @@ function App() {
         xAxisLabel="Date"
         yAxisLabel="Value"
       />
-      <LineChart
+      {/* <LineChart
         height="100%"
         data={unemployment}
         xKey="date"
@@ -119,7 +119,7 @@ function App() {
         yGrid={true}
         xAxisLabel="Date"
         yAxisLabel="Value"
-      />
+      /> */}
     </div>
   )
 }

--- a/src/charts/AreaChart/AreaChart.tsx
+++ b/src/charts/AreaChart/AreaChart.tsx
@@ -1,11 +1,17 @@
 /** App.js */
-import React, { useState, useMemo} from "react";
-import * as d3 from "d3";
-import { AreaChartProps, ColorScale, xAccessorFunc, Data, yAccessorFunc } from '../../../types';
-import {Axis} from "../../components/ContinuousAxis";
-import { useResponsive } from '../../hooks/useResponsive';
-import { xScaleDef } from '../../functionality/xScale';
-import { yScaleDef } from '../../functionality/yScale';
+import React, { useState, useMemo } from "react"
+import * as d3 from "d3"
+import {
+  AreaChartProps,
+  ColorScale,
+  xAccessorFunc,
+  Data,
+  yAccessorFunc,
+} from "../../../types"
+import { Axis } from "../../components/ContinuousAxis"
+import { useResponsive } from "../../hooks/useResponsive"
+import { xScaleDef } from "../../functionality/xScale"
+import { yScaleDef } from "../../functionality/yScale"
 import { d3Voronoi } from "../../functionality/voronoi"
 import ListeningRect from "../../components/ListeningRect"
 import { Tooltip } from "../../components/Tooltip"
@@ -14,9 +20,8 @@ import {
   getYAxisCoordinates,
   getMargins,
   inferXDataType,
-  transformSkinnyToWide
-} from "../../utils";
-
+  transformSkinnyToWide,
+} from "../../utils"
 
 export default function AreaChart({
   data,
@@ -110,46 +115,39 @@ export default function AreaChart({
   colorScale.domain(keys)
 
   return (
-      <svg ref={anchor} width={width} height={height}>
-         <g transform={translate}>
-      {yAxis && (
-        <Axis
-        x={yAxisX}
-        y={yAxisY}
-        height={cHeight}
-        width={cWidth}
-        margin={margin}
-        scale={yScale}
-        type={yAxis}
-        yGrid={yGrid}
-        label={yAxisLabel}
-        />
-      )}
-      {xAxis && (
-        <Axis
-        x={xAxisX}
-        y={xAxisY}
-        height={cHeight}
-        width={cWidth}
-        margin={margin}
-        scale={xScale}
-        xGrid={xGrid}
-        type={xAxis}
-        label={xAxisLabel}
-        xTicksValue={xTicksValue}
-        />
-      )}
-        {layers.map((layer, i) => (
-          <path
-            key={i}
-            d={areaGenerator(layer)}
-            fill= {colorScale(layer.key)}
+    <svg ref={anchor} width={width} height={height}>
+      <g transform={translate}>
+        {yAxis && (
+          <Axis
+            x={yAxisX}
+            y={yAxisY}
+            height={cHeight}
+            width={cWidth}
+            margin={margin}
+            scale={yScale}
+            type={yAxis}
+            yGrid={yGrid}
+            label={yAxisLabel}
           />
+        )}
+        {xAxis && (
+          <Axis
+            x={xAxisX}
+            y={xAxisY}
+            height={cHeight}
+            width={cWidth}
+            margin={margin}
+            scale={xScale}
+            xGrid={xGrid}
+            type={xAxis}
+            label={xAxisLabel}
+            xTicksValue={xTicksValue}
+          />
+        )}
+        {layers.map((layer, i) => (
+          <path key={i} d={areaGenerator(layer)} fill={colorScale(layer.key)} />
         ))}
-       
-        {tooltip && 
-        <Tooltip x={tooltip.cx} y={tooltip.cy} />
-        }
+        {tooltip && <Tooltip x={tooltip.cx} y={tooltip.cy} />}
 
         <ListeningRect
           data={data}

--- a/src/components/Rectangle.tsx
+++ b/src/components/Rectangle.tsx
@@ -1,15 +1,27 @@
-import React from 'react';
-import {RectangleProps} from '../../types'
+import React from "react"
+import { RectangleProps } from "../../types"
 
-export const Rectangle = React.memo(({x, y, width, height, fill}: RectangleProps):JSX.Element => {
-  console.log('rectangle rendered')
-  return (
-<rect
-            x={x}
-            y={y}
-            width={width}
-            height={height}
-            fill={fill}
-          />  )
-})
-
+export const Rectangle = React.memo(
+  ({ x, y, width, height, fill, setTooltip }: RectangleProps): JSX.Element => {
+    console.log("rectangle rendered")
+    let cellCenter = { cx: 0, cy: 0 }
+    if (typeof x === "number" && typeof y === "number") {
+      const cx = x + width / 2
+      const cy = y - 50
+      cellCenter = { cx, cy }
+    }
+    return (
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        onMouseOver={(e) => {
+          setTooltip ? setTooltip(cellCenter) : null
+        }}
+        onMouseOut={() => (setTooltip ? setTooltip(false) : null)}
+      />
+    )
+  }
+)

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,5 @@
-import * as d3 from 'd3';
-import React from 'react';
+import * as d3 from "d3"
+import React from "react"
 export interface Data {
   [key: string]: any
 }
@@ -137,10 +137,11 @@ export interface CircleProps {
 
 export interface RectangleProps {
   x: number | undefined
-  y:number
+  y: number
   width: number
   height: number
-  fill: string 
+  fill: string
+  setTooltip?: React.Dispatch<any>
 }
 
 export interface LineProps {
@@ -157,8 +158,8 @@ export interface VoronoiProps {
   opacity: number
   d: string | undefined
   cellCenter?: { cx: number; cy: number }
-  setTooltip?: React.Dispatch<any>
   data?: any
+  setTooltip?: React.Dispatch<any>
 }
 
 export type ColorScale = d3.ScaleOrdinal<string, string, never>
@@ -178,9 +179,9 @@ export type ScaleFunc =
   | d3.ScaleLinear<number, number, never>
   | d3.ScaleTime<number, number, never>
 
-export type xAccessorFunc = (d: any) => number | Date;
+export type xAccessorFunc = (d: any) => number | Date
 
-export type yAccessorFunc = (d: any) => number;
+export type yAccessorFunc = (d: any) => number
 
 export type Domain = number | Date | undefined
 
@@ -193,7 +194,7 @@ export interface VoronoiProps {
 export interface VoronoiBody {
   data: Data
   voronoi: d3.Voronoi<string>
-  xScale:ScaleFunc
+  xScale: ScaleFunc
   yScale: ScaleFunc
   xAccessor: xAccessorFunc
   yAccessor: yAccessorFunc


### PR DESCRIPTION
The Rectangle component just needs the right events added to it to get the Tooltip component to appear. So, this PR adds the Tooltip to the Bar Chart and updated the Rectangle component to listen to the right events and position the Tooltip in a reasonable position.