### PR TITLE
Added a Tootlip to the Pie Chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import skinny_fruit from "./data/skinny_fruit.json"
 function App() {
   return (
     <div className="app">
-      {/* <PieChart
+      <PieChart
         data={fruit}
         label="label"
         value="value"
@@ -67,7 +67,7 @@ function App() {
         // yGrid={true}
         xAxisLabel="Date"
         yAxisLabel="Value"
-      /> */}
+      />
       <BarChart
         height="300"
         data={skinny_fruit}
@@ -92,7 +92,7 @@ function App() {
         xAxisLabel="Date"
         yAxisLabel="Value"
       />
-      {/* <LineChart
+      <LineChart
         height="100%"
         data={unemployment}
         xKey="date"
@@ -108,7 +108,7 @@ function App() {
       />
       <LineChart
         height="500"
-        width='500'
+        width="500"
         data={portfolio}
         xKey="date"
         xDataType="date"
@@ -119,7 +119,7 @@ function App() {
         yGrid={true}
         xAxisLabel="Date"
         yAxisLabel="Value"
-      /> */}
+      />
     </div>
   )
 }

--- a/src/charts/PieChart/PieChart.tsx
+++ b/src/charts/PieChart/PieChart.tsx
@@ -1,11 +1,12 @@
 /** App.js */
-import React from "react";
-import * as d3 from "d3";
-import { useResponsive } from '../../hooks/useResponsive';
-import { PieChartProps } from "../../../types";
-import { ColorLegend } from "../../components/ColorLegend";
-import { Line } from '../../components/Line';
-import { checkRadiusDimension, calculateOuterRadius } from "../../utils";
+import React, { useState } from "react"
+import * as d3 from "d3"
+import { useResponsive } from "../../hooks/useResponsive"
+import { PieChartProps } from "../../../types"
+import { ColorLegend } from "../../components/ColorLegend"
+import { Arc } from "../../components/Arc"
+import { Tooltip } from "../../components/Tooltip"
+import { checkRadiusDimension, calculateOuterRadius } from "../../utils"
 
 export default function PieChart({
   data,
@@ -14,27 +15,32 @@ export default function PieChart({
   outerRadius,
   innerRadius,
   colorScheme = d3.schemeCategory10,
-  legend
+  legend,
 }: PieChartProps): JSX.Element {
+  const [tooltip, setTooltip] = useState<false | any>(false)
 
-  const {anchor, cHeight, cWidth}  = useResponsive();
-  
+  const { anchor, cHeight, cWidth } = useResponsive()
+
   const margin = {
     top: 20,
     right: 20,
     bottom: 20,
     left: 20,
-  };
-  outerRadius = outerRadius ? checkRadiusDimension(cHeight,cWidth, outerRadius, margin): calculateOuterRadius(cHeight,cWidth,margin)
-  innerRadius = innerRadius ? checkRadiusDimension(outerRadius, outerRadius, innerRadius, margin) : 0
+  }
+  outerRadius = outerRadius
+    ? checkRadiusDimension(cHeight, cWidth, outerRadius, margin)
+    : calculateOuterRadius(cHeight, cWidth, margin)
+  innerRadius = innerRadius
+    ? checkRadiusDimension(outerRadius, outerRadius, innerRadius, margin)
+    : 0
 
   type ColorScale = d3.ScaleOrdinal<string, string, never>
 
-  const translate = `translate(${cWidth/2}, ${cHeight/2})`
-  
+  const translate = `translate(${cWidth / 2}, ${cHeight / 2})`
+
   const keys: string[] = []
   for (let entry of data) {
-    const property = entry[label];
+    const property = entry[label]
     if (property && !keys.includes(property)) {
       keys.push(property)
     }
@@ -43,55 +49,65 @@ export default function PieChart({
   const colorScale: ColorScale = d3.scaleOrdinal(colorScheme)
   colorScale.domain(keys)
 
-  const arcGenerator : any = d3
+  const arcGenerator: any = d3
     .arc()
     .innerRadius(innerRadius)
-    .outerRadius(outerRadius);
+    .outerRadius(outerRadius)
 
-  const pieGenerator : any = d3
+  const pieGenerator: any = d3
     .pie()
     .padAngle(0)
-    .value((d : any) => d[value]);
+    .value((d: any) => d[value])
 
-  const pie : any = pieGenerator(data)
+  const pie: any = pieGenerator(data)
 
-  const textTranform = (d : any) => {
-    const [x , y] = arcGenerator.centroid(d);
+  const textTranform = (d: any) => {
+    const [x, y] = arcGenerator.centroid(d)
     return `translate(${x}, ${y})`
   }
 
-  return(
+  return (
     <svg ref={anchor} width={"100%"} height={"100%"}>
-     <g transform = {translate}  >
-        {pie.map((d: any, i:number) => 
-        <g key = {"g" + i} >
-          <Line 
-            key={d.label}
-            fill={colorScale(keys[i])}
-            stroke = "#ffffff"
-            strokeWidth = "0px"
-            d = {arcGenerator(d)}
-            id = {"arc-" + i}
-          />
-        <text
-          transform = {textTranform(d)}
-          textAnchor = {"middle"}
-          alignmentBaseline = {"middle"}
-          fill = {"black"}
-        >
-          {d.data[value]}
-        </text>
-        </g>)}
-        { // If legend prop is true, render legend component:
-        legend && <ColorLegend 
-          colorLegendLabel={'Fruit' /**we need a way to derive this either from data or as an extra prop passed in */} 
-          xPosition={outerRadius+15 /* Where legend is placed on page */}
-          yPosition={0/* Where legend is placed on page */}
-          circleRadius={5 /* Radius of each color swab in legend */}
-          // tickSpacing={22 /* Vertical space between each line of legend */}
-          // tickTextOffset={12 /* How much the text label is pushed to the right of the color swab */}
-          colorScale={colorScale}
-        />}
+      <g transform={translate}>
+        {pie.map((d: any, i: number) => (
+          <g key={"g" + i}>
+            <Arc
+              key={d.label}
+              fill={colorScale(keys[i])}
+              stroke="#ffffff"
+              strokeWidth="0px"
+              d={arcGenerator(d)}
+              id={"arc-" + i}
+              setTooltip={setTooltip}
+            />
+            <text
+              style={{ pointerEvents: "none" }}
+              transform={textTranform(d)}
+              textAnchor={"middle"}
+              alignmentBaseline={"middle"}
+              fill={"black"}
+            >
+              {d.data[value]}
+            </text>
+          </g>
+        ))}
+        {
+          // If legend prop is true, render legend component:
+          legend && (
+            <ColorLegend
+              colorLegendLabel={
+                "Fruit" /**we need a way to derive this either from data or as an extra prop passed in */
+              }
+              xPosition={outerRadius + 15 /* Where legend is placed on page */}
+              yPosition={0 /* Where legend is placed on page */}
+              circleRadius={5 /* Radius of each color swab in legend */}
+              // tickSpacing={22 /* Vertical space between each line of legend */}
+              // tickTextOffset={12 /* How much the text label is pushed to the right of the color swab */}
+              colorScale={colorScale}
+            />
+          )
+        }
+        {tooltip && <Tooltip x={tooltip.cx} y={tooltip.cy} />}
       </g>
     </svg>
   )

--- a/src/components/Arc.tsx
+++ b/src/components/Arc.tsx
@@ -1,0 +1,89 @@
+import React from "react"
+import * as d3 from "d3"
+
+import {
+  ArcProps,
+  Data,
+  Margin,
+  ScaleFunc,
+  xAccessorFunc,
+  yAccessorFunc,
+} from "../../types"
+
+export const Arc = React.memo(
+  ({
+    fill = "none",
+    stroke,
+    strokeWidth = "1px",
+    d,
+    setTooltip,
+  }: ArcProps): JSX.Element => {
+    function onMouseMove(e: any) {
+      const mousePosition = d3.pointer(e)
+      const hoveredX = mousePosition[0]
+      const hoveredY = mousePosition[1]
+      // console.log("HOVERED Y ", hoveredY)
+
+      // ****************************************
+      // Find x position
+      // ****************************************
+      // const getDistanceFromHoveredX = function (d: any) {
+      //   // This StackOverFlow Article helped me with this TS issue
+      //   // https://stackoverflow.com/questions/48274028/the-left-hand-and-right-hand-side-of-an-arithmetic-operation-must-be-of-type-a
+      //   return Math.abs(xAccessor(d).valueOf() - hoveredX.valueOf())
+      // }
+
+      // const closestXIndex = d3.leastIndex(data, (a, b) => {
+      //   return getDistanceFromHoveredX(a) - getDistanceFromHoveredX(b)
+      // })
+
+      // if (typeof closestXIndex === "number") {
+      //   const closestDataPoint = data[closestXIndex]
+      //   const closestXValue = xAccessor(closestDataPoint)
+      //   cellCenter.cx = xScale(closestXValue)
+      // }
+
+      // ****************************************
+      // Find y position
+      // ****************************************
+      // const closestYSequence = layers.map((layer) => {
+      //   if (typeof closestXIndex === "number") {
+      //     return layer[closestXIndex][1]
+      //   }
+      // })
+
+      // const getDistanceFromHoveredY = function (d: any) {
+      //   return Math.abs(d - hoveredY.valueOf())
+      // }
+
+      // const closestYIndex = d3.leastIndex(closestYSequence, (a, b) => {
+      //   return getDistanceFromHoveredY(a) - getDistanceFromHoveredY(b)
+      // })
+
+      // if (typeof closestYIndex === "number") {
+      //   const closestKey = layers[closestYIndex].key
+      //   if (typeof closestXIndex === "number") {
+      //     const closestValue = layers[closestYIndex][closestXIndex][1]
+      //     cellCenter.cy = yScale(closestValue)
+      //     // console.log(`The Closest Y is ${closestKey} ${closestValue}`)
+      //   }
+      // }
+
+      if (setTooltip) {
+        setTooltip({ cx: hoveredX, cy: hoveredY })
+      }
+    }
+
+    return (
+      <path
+        className="arc"
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        d={d}
+        onMouseMove={onMouseMove}
+        onMouseLeave={() => (setTooltip ? setTooltip(false) : null)}
+      />
+    )
+  }
+)

--- a/types.ts
+++ b/types.ts
@@ -152,6 +152,15 @@ export interface LineProps {
   id?: string | number
 }
 
+export interface ArcProps {
+  fill: string
+  stroke: string
+  strokeWidth: string
+  d: string | undefined
+  id?: string | number
+  setTooltip?: React.Dispatch<any>
+}
+
 export interface VoronoiProps {
   fill: string
   stroke: string


### PR DESCRIPTION
The Pie Chart was using the Line Component as its share and I needed a different shape, so I added an Arc Component. I use that Arc Component in the Pie Chart rather than the Line Component. We also have the appropriate even listeners on the Arc Component to get the Tooltip showing up.